### PR TITLE
ci: Add release workflow

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -43,6 +43,6 @@ jobs:
         with:
           profile: cover.out
           local-prefix: github.com/lukecold/event-driver
-          threshold-file: 70
-          threshold-package: 70
-          threshold-total: 70
+          threshold-file: 80
+          threshold-package: 80
+          threshold-total: 80

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -43,6 +43,6 @@ jobs:
         with:
           profile: cover.out
           local-prefix: github.com/lukecold/event-driver
-          threshold-file: 0
-          threshold-package: 30
-          threshold-total: 30
+          threshold-file: 70
+          threshold-package: 70
+          threshold-total: 70

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -1,14 +1,6 @@
 name: go-tests
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    types:
-      - edited
-      - opened
-      - reopened
-      - synchronize
+on: [workflow_call]
 
 jobs:
   build:

--- a/.github/workflows/on-deployment.yaml
+++ b/.github/workflows/on-deployment.yaml
@@ -1,0 +1,11 @@
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  tests:
+    uses: ./.github/workflows/go-tests.yml
+
+  deploy:
+    needs: [ tests ]
+    uses: ./.github/workflows/semantic-release.yml

--- a/.github/workflows/on-deployment.yaml
+++ b/.github/workflows/on-deployment.yaml
@@ -4,8 +4,8 @@ on:
 
 jobs:
   tests:
-    uses: ./.github/workflows/go-tests.yml
+    uses: ./.github/workflows/go-tests.yaml
 
   deploy:
     needs: [ tests ]
-    uses: ./.github/workflows/semantic-release.yml
+    uses: ./.github/workflows/semantic-release.yaml

--- a/.github/workflows/on-deployment.yaml
+++ b/.github/workflows/on-deployment.yaml
@@ -1,3 +1,5 @@
+name: deploy
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/on-pull-requests.yaml
+++ b/.github/workflows/on-pull-requests.yaml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   tests:
-    uses: ./.github/workflows/go-tests.yml
+    uses: ./.github/workflows/go-tests.yaml

--- a/.github/workflows/on-pull-requests.yaml
+++ b/.github/workflows/on-pull-requests.yaml
@@ -1,0 +1,11 @@
+on:
+  pull_request:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  tests:
+    uses: ./.github/workflows/go-tests.yml

--- a/.github/workflows/on-pull-requests.yaml
+++ b/.github/workflows/on-pull-requests.yaml
@@ -1,3 +1,5 @@
+name: pull-requests
+
 on:
   pull_request:
     types:

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -7,10 +7,10 @@ release:
   runs-on: ubuntu-latest
   needs: [ go-tests ]
   steps:
-    - name: Checkout
+    - name: checkout
       uses: actions/checkout@v4
 
-    - name: Semantic Release
+    - name: semantic release
       uses: cycjimmy/semantic-release-action@v4
       with:
         branches: ['main']

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -1,0 +1,22 @@
+name: semantic-release
+
+on: [workflow_call]
+
+release:
+  name: semantic-release
+  runs-on: ubuntu-latest
+  needs: [ go-tests ]
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Semantic Release
+      uses: cycjimmy/semantic-release-action@v4
+      with:
+        branches: ['main']
+        extra_plugins: |
+          @semantic-release/git
+          @semantic-release/exec
+          @semantic-release/changelog
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.golangci.json
+++ b/.golangci.json
@@ -1,0 +1,50 @@
+{
+  "_ignore": "DO NOT MODIFY THIS FILE: https://github.com/honestbank/.github/blob/main/docs/about.md",
+  "run": {
+    "skip-files": [
+      "graph"
+    ],
+    "skip-dirs": [
+      ".*/generated/*"
+    ],
+    "skip-dirs-use-default": true,
+    "tests": true
+  },
+  "linters": {
+    "enable": [
+      "deadcode",
+      "errcheck",
+      "gosimple",
+      "govet",
+      "ineffassign",
+      "staticcheck",
+      "structcheck",
+      "typecheck",
+      "unused",
+      "varcheck",
+      "gofmt",
+      "goimports",
+      "nestif",
+      "ifshort",
+      "asciicheck",
+      "exhaustive",
+      "exportloopref",
+      "forbidigo",
+      "gocyclo",
+      "gofmt",
+      "goimports",
+      "ifshort",
+      "makezero",
+      "misspell",
+      "nakedret",
+      "nestif",
+      "nilerr",
+      "nlreturn",
+      "nolintlint",
+      "testpackage",
+      "unconvert",
+      "wastedassign",
+      "whitespace"
+    ]
+  }
+}


### PR DESCRIPTION
## Changes

- The semantic-release workflow would release the versions automatically.
- Call `go-tests` and `semantic-release` from `on-pull-requests` and `on-deployment` for cross-workflow dependency.
- Added `.golangci.json` to explicitly list the linters to run
- Bumped the test coverage requirement up to 80%