### PR TITLE
ci: Put semantic-release workflow under jobs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+## Checklist
+- [ ] I've run and passed the [`pre-commit`](https://pre-commit.com).
+- [ ] I've put adequate descriptions that explains why this change is made.
+
+## Description

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -2,21 +2,21 @@ name: semantic-release
 
 on: [workflow_call]
 
-release:
-  name: semantic-release
-  runs-on: ubuntu-latest
-  needs: [ go-tests ]
-  steps:
-    - name: checkout
-      uses: actions/checkout@v4
+jobs:
+  release:
+    name: semantic-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
 
-    - name: semantic release
-      uses: cycjimmy/semantic-release-action@v4
-      with:
-        branches: ['main']
-        extra_plugins: |
-          @semantic-release/git
-          @semantic-release/exec
-          @semantic-release/changelog
-      env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: semantic release
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          branches: ['main']
+          extra_plugins: |
+            @semantic-release/git
+            @semantic-release/exec
+            @semantic-release/changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Checklist
- [x] I've run and passed the [`pre-commit`](https://pre-commit.com).
- [x] I've put adequate descriptions that explains why this change is made.

## Description

- Fixed the issue that the `on-deployment` workflow wasn't able to run since the dependency workflow `semantic-release` weren't under `jobs`.
- Added a `pull_request_template` to remind contributors of the TODOs.