### PR TITLE
ci: Add write permission to deployment workflow

### DIFF
--- a/.github/workflows/on-deployment.yaml
+++ b/.github/workflows/on-deployment.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   tests:
     uses: ./.github/workflows/go-tests.yaml


### PR DESCRIPTION
## Checklist
- [x] I've run and passed the [`pre-commit`](https://pre-commit.com).
- [x] I've put adequate descriptions that explains why this change is made.

## Description
The `on-deployment` workflow wasn't able to run since the required write permission wasn't met.