### PR TITLE
feat: Implement Condition and add richer docs

### DIFF
--- a/handlers/cache/cache.go
+++ b/handlers/cache/cache.go
@@ -8,7 +8,8 @@ import (
 	"github.com/lukecold/event-driver/storage"
 )
 
-// ConflictResolver resolves the case when the input matches an existing record in the cache
+// ConflictResolver implements handlers.Handler that resolves the case
+// when the input matches an existing record in the cache.
 type ConflictResolver interface {
 	Resolve(ctx context.Context, in event.Message, next handlers.CallNext) error
 }

--- a/handlers/joiner/condition.go
+++ b/handlers/joiner/condition.go
@@ -1,7 +1,135 @@
 package joiner
 
-// TODO: implement me
-// requirement: be able to match (AND|OR|()) operations
+// Condition evaluates the sources with the criteria.
 type Condition interface {
-	Match(sources []string) bool
+	Evaluate(sources []string) bool
+}
+
+// pointer to struct condition implements the interface Condition.
+type condition struct {
+	evaluate func(sources []string) bool
+}
+
+func (c *condition) Evaluate(sources []string) bool {
+	return c.evaluate(sources)
+}
+
+func (c *condition) And(conditions ...Condition) *condition {
+	return &condition{
+		evaluate: func(sources []string) bool {
+			if !c.evaluate(sources) {
+				return false
+			}
+			for _, cond := range conditions {
+				if !cond.Evaluate(sources) {
+					return false
+				}
+			}
+
+			return true
+		},
+	}
+}
+
+func (c *condition) Or(conditions ...Condition) *condition {
+	return &condition{
+		evaluate: func(sources []string) bool {
+			if c.evaluate(sources) {
+				return true
+			}
+			for _, cond := range conditions {
+				if cond.Evaluate(sources) {
+					return true
+				}
+			}
+
+			return false
+		},
+	}
+}
+
+func (c *condition) XOr(other Condition) *condition {
+	return &condition{
+		evaluate: func(sources []string) bool {
+			return c.Evaluate(sources) != other.Evaluate(sources)
+		},
+	}
+}
+
+// MatchAll returns a Condition to verify that all required sources are present.
+func MatchAll(requiredSources ...string) *condition {
+	if len(requiredSources) == 0 {
+		return &condition{evaluate: alwaysTrue}
+	}
+
+	return &condition{
+		evaluate: func(sources []string) bool {
+			if len(sources) < len(requiredSources) {
+				return false
+			}
+
+			isSourcePresent := make(map[string]bool)
+			for _, source := range sources {
+				isSourcePresent[source] = true
+			}
+			for _, requiredSource := range requiredSources {
+				if !isSourcePresent[requiredSource] {
+					return false
+				}
+			}
+
+			return true
+		},
+	}
+}
+
+// MatchAny returns a Condition to verify that any sources-to-match are present.
+func MatchAny(sourcesToMatch ...string) *condition {
+	if len(sourcesToMatch) == 0 {
+		return &condition{evaluate: alwaysTrue}
+	}
+	isSourceMatched := make(map[string]bool)
+	for _, source := range sourcesToMatch {
+		isSourceMatched[source] = true
+	}
+
+	return &condition{
+		evaluate: func(sources []string) bool {
+			for _, source := range sources {
+				if isSourceMatched[source] {
+					return true
+				}
+			}
+
+			return false
+		},
+	}
+}
+
+// MatchNone returns a Condition to verify that none of the sources-to-exclude are present.
+// note that this condition would pass if input sources is empty or nil.
+func MatchNone(sourcesToExclude ...string) *condition {
+	if len(sourcesToExclude) == 0 {
+		return &condition{evaluate: alwaysTrue}
+	}
+	isSourceUnexpected := make(map[string]bool)
+	for _, source := range sourcesToExclude {
+		isSourceUnexpected[source] = true
+	}
+
+	return &condition{
+		evaluate: func(sources []string) bool {
+			for _, source := range sources {
+				if isSourceUnexpected[source] {
+					return false
+				}
+			}
+
+			return true
+		},
+	}
+}
+
+func alwaysTrue(_ []string) bool {
+	return true
 }

--- a/handlers/joiner/condition_test.go
+++ b/handlers/joiner/condition_test.go
@@ -1,0 +1,245 @@
+package joiner_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lukecold/event-driver/handlers/joiner"
+)
+
+type conditionTestCase struct {
+	sources     []string
+	condition   joiner.Condition
+	shouldMatch bool
+}
+
+func TestMatchAll(t *testing.T) {
+	matchBoth := joiner.MatchAll("source1", "source2")
+
+	testCases := map[string]conditionTestCase{
+		"all required sources present": {
+			sources:     []string{"source1", "source2"},
+			condition:   matchBoth,
+			shouldMatch: true,
+		},
+		"additional sources present": {
+			sources:     []string{"other", "source1", "source2"},
+			condition:   matchBoth,
+			shouldMatch: true,
+		},
+		"no required sources": {
+			sources:     []string{"any"},
+			condition:   joiner.MatchAll(),
+			shouldMatch: true,
+		},
+		"required source(s) missing": {
+			sources:     []string{"source1"},
+			condition:   matchBoth,
+			shouldMatch: false,
+		},
+		"empty input": {
+			sources:     []string{},
+			condition:   matchBoth,
+			shouldMatch: false,
+		},
+		"null input": {
+			sources:     nil,
+			condition:   matchBoth,
+			shouldMatch: false,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			isMatch := testCase.condition.Evaluate(testCase.sources)
+			assert.Equal(t, testCase.shouldMatch, isMatch)
+		})
+	}
+}
+
+func TestMatchAny(t *testing.T) {
+	matchEither := joiner.MatchAny("source1", "source2")
+
+	testCases := map[string]conditionTestCase{
+		"all sources present": {
+			sources:     []string{"source1", "source2"},
+			condition:   matchEither,
+			shouldMatch: true,
+		},
+		"one of the sources present": {
+			sources:     []string{"source2"},
+			condition:   matchEither,
+			shouldMatch: true,
+		},
+		"additional sources present": {
+			sources:     []string{"other", "source1", "source2"},
+			condition:   matchEither,
+			shouldMatch: true,
+		},
+		"no sources to match": {
+			sources:     []string{"any"},
+			condition:   joiner.MatchAny(),
+			shouldMatch: true,
+		},
+		"empty input": {
+			sources:     []string{},
+			condition:   matchEither,
+			shouldMatch: false,
+		},
+		"null input": {
+			sources:     nil,
+			condition:   matchEither,
+			shouldMatch: false,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			isMatch := testCase.condition.Evaluate(testCase.sources)
+			assert.Equal(t, testCase.shouldMatch, isMatch)
+		})
+	}
+}
+
+func TestMatchNone(t *testing.T) {
+	matchNeither := joiner.MatchNone("source1", "source2")
+
+	testCases := map[string]conditionTestCase{
+		"one unexpected sources present": {
+			sources:     []string{"source1", "other"},
+			condition:   matchNeither,
+			shouldMatch: false,
+		},
+		"all unexpected sources present": {
+			sources:     []string{"source1", "source2", "other"},
+			condition:   matchNeither,
+			shouldMatch: false,
+		},
+		"no sources to exclude": {
+			sources:     []string{"any"},
+			condition:   joiner.MatchNone(),
+			shouldMatch: true,
+		},
+		"none of the unexpected sources present": {
+			sources:     []string{"other", "more"},
+			condition:   matchNeither,
+			shouldMatch: true,
+		},
+		"empty input": {
+			sources:     []string{},
+			condition:   matchNeither,
+			shouldMatch: true,
+		},
+		"null input": {
+			sources:     nil,
+			condition:   matchNeither,
+			shouldMatch: true,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			isMatch := testCase.condition.Evaluate(testCase.sources)
+			assert.Equal(t, testCase.shouldMatch, isMatch)
+		})
+	}
+}
+
+func TestLogicOperations(t *testing.T) {
+	passCondition := joiner.MatchAny()
+	failCondition := joiner.MatchAll("not-exist")
+	var sources []string
+	assert.True(t, passCondition.Evaluate(sources))
+	assert.False(t, failCondition.Evaluate(sources))
+
+	testCases := map[string]conditionTestCase{
+		"true AND true = true": {
+			condition:   passCondition.And(passCondition),
+			shouldMatch: true,
+		},
+		"true AND false = false": {
+			condition:   passCondition.And(failCondition),
+			shouldMatch: false,
+		},
+		"false AND true = false": {
+			condition:   failCondition.And(passCondition),
+			shouldMatch: false,
+		},
+		"false AND false = false": {
+			condition:   failCondition.And(failCondition),
+			shouldMatch: false,
+		},
+		"true AND true AND true = true": {
+			condition:   passCondition.And(passCondition, passCondition),
+			shouldMatch: true,
+		},
+		"true AND true AND false = false": {
+			condition:   passCondition.And(passCondition, failCondition),
+			shouldMatch: false,
+		},
+		"true OR true = true": {
+			condition:   passCondition.Or(passCondition),
+			shouldMatch: true,
+		},
+		"true OR false = true": {
+			condition:   passCondition.Or(failCondition),
+			shouldMatch: true,
+		},
+		"false OR true = true": {
+			condition:   failCondition.Or(passCondition),
+			shouldMatch: true,
+		},
+		"false OR false = false": {
+			condition:   failCondition.Or(failCondition),
+			shouldMatch: false,
+		},
+		"true OR true OR true = true": {
+			condition:   passCondition.Or(passCondition, passCondition),
+			shouldMatch: true,
+		},
+		"true OR true OR false = true": {
+			condition:   passCondition.Or(passCondition, failCondition),
+			shouldMatch: true,
+		},
+		"false OR false OR false = false": {
+			condition:   failCondition.Or(failCondition, failCondition),
+			shouldMatch: false,
+		},
+		"true XOR true = false": {
+			condition:   passCondition.XOr(passCondition),
+			shouldMatch: false,
+		},
+		"true XOR false = true": {
+			condition:   passCondition.XOr(failCondition),
+			shouldMatch: true,
+		},
+		"false XOR true = true": {
+			condition:   failCondition.XOr(passCondition),
+			shouldMatch: true,
+		},
+		"false XOR false = false": {
+			condition:   failCondition.XOr(failCondition),
+			shouldMatch: false,
+		},
+		"false AND true OR true = true": {
+			condition:   failCondition.And(passCondition).Or(passCondition),
+			shouldMatch: true,
+		},
+		"false AND (true OR true) = false": {
+			condition:   failCondition.And(passCondition.Or(passCondition)),
+			shouldMatch: false,
+		},
+		"false AND true OR true XOR true = false": {
+			condition:   failCondition.And(passCondition).Or(passCondition).XOr(passCondition),
+			shouldMatch: false,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			isMatch := testCase.condition.Evaluate(testCase.sources)
+			assert.Equal(t, testCase.shouldMatch, isMatch)
+		})
+	}
+}

--- a/handlers/joiner/joiner_test.go
+++ b/handlers/joiner/joiner_test.go
@@ -1,0 +1,118 @@
+package joiner_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/lukecold/event-driver/event"
+	"github.com/lukecold/event-driver/handlers/joiner"
+	"github.com/lukecold/event-driver/mocks"
+	"github.com/lukecold/event-driver/storage"
+)
+
+func TestJoiner(t *testing.T) {
+	t.Run("condition met", func(t *testing.T) {
+		ctx := context.TODO()
+		input1 := event.NewMessage("key", "source1", "content1")
+		input2 := event.NewMessage("key", "source2", "content2")
+
+		ctrl := gomock.NewController(t)
+		callNext := mocks.NewMockCallNext(ctrl)
+		condition := joiner.MatchAll("source1").
+			And(joiner.MatchAny("source2", "source3"))
+		eventStore := storage.NewInMemoryStore()
+
+		expectedMessage := event.NewMessage("key", "composed-event", `{"source1":"content1","source2":"content2"}`)
+		callNext.EXPECT().Call(gomock.Any(), expectedMessage).AnyTimes()
+
+		handler := joiner.New(condition, eventStore)
+		err := handler.Process(ctx, input1, callNext)
+		assert.NoError(t, err)
+		err = handler.Process(ctx, input2, callNext)
+		assert.NoError(t, err)
+	})
+
+	t.Run("condition not met", func(t *testing.T) {
+		ctx := context.TODO()
+		input1 := event.NewMessage("key", "source2", "content2")
+		input2 := event.NewMessage("key", "source3", "content3")
+
+		ctrl := gomock.NewController(t)
+		callNext := mocks.NewMockCallNext(ctrl)
+		condition := joiner.MatchAll("source1").
+			And(joiner.MatchAny("source2", "source3"))
+		eventStore := storage.NewInMemoryStore()
+
+		handler := joiner.New(condition, eventStore)
+		err := handler.Process(ctx, input1, callNext)
+		assert.NoError(t, err)
+		err = handler.Process(ctx, input2, callNext)
+		assert.NoError(t, err)
+	})
+
+	t.Run("failed to pass to next", func(t *testing.T) {
+		ctx := context.TODO()
+		input1 := event.NewMessage("key", "source1", "content1")
+		input2 := event.NewMessage("key", "source2", "content2")
+
+		ctrl := gomock.NewController(t)
+		callNext := mocks.NewMockCallNext(ctrl)
+		condition := joiner.MatchAll("source1").
+			And(joiner.MatchAny("source2", "source3"))
+		eventStore := storage.NewInMemoryStore()
+
+		expectedMessage := event.NewMessage("key", "composed-event", `{"source1":"content1","source2":"content2"}`)
+		callNext.EXPECT().Call(gomock.Any(), expectedMessage).AnyTimes().Return(errors.New("test"))
+
+		handler := joiner.New(condition, eventStore)
+		err := handler.Process(ctx, input1, callNext)
+		assert.NoError(t, err)
+		err = handler.Process(ctx, input2, callNext)
+		assert.Error(t, err)
+	})
+
+	t.Run("failed to persist", func(t *testing.T) {
+		ctx := context.TODO()
+		input1 := event.NewMessage("key", "source1", "content1")
+		input2 := event.NewMessage("key", "source2", "content2")
+
+		ctrl := gomock.NewController(t)
+		callNext := mocks.NewMockCallNext(ctrl)
+		condition := joiner.MatchAll("source1").
+			And(joiner.MatchAny("source2", "source3"))
+		eventStore := mocks.NewMockEventStore(ctrl)
+
+		eventStore.EXPECT().Persist(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("test")).Times(2)
+
+		handler := joiner.New(condition, eventStore)
+		err := handler.Process(ctx, input1, callNext)
+		assert.Error(t, err)
+		err = handler.Process(ctx, input2, callNext)
+		assert.Error(t, err)
+	})
+
+	t.Run("failed to lookup by key", func(t *testing.T) {
+		ctx := context.TODO()
+		input1 := event.NewMessage("key", "source1", "content1")
+		input2 := event.NewMessage("key", "source2", "content2")
+
+		ctrl := gomock.NewController(t)
+		callNext := mocks.NewMockCallNext(ctrl)
+		condition := joiner.MatchAll("source1").
+			And(joiner.MatchAny("source2", "source3"))
+		eventStore := mocks.NewMockEventStore(ctrl)
+
+		eventStore.EXPECT().Persist(gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
+		eventStore.EXPECT().LookUpByKey(gomock.Any()).Return(nil, errors.New("test")).Times(2)
+
+		handler := joiner.New(condition, eventStore)
+		err := handler.Process(ctx, input1, callNext)
+		assert.Error(t, err)
+		err = handler.Process(ctx, input2, callNext)
+		assert.Error(t, err)
+	})
+}

--- a/handlers/transformer/rules.go
+++ b/handlers/transformer/rules.go
@@ -6,6 +6,8 @@ import (
 	"github.com/lukecold/event-driver/event"
 )
 
+// Rule defines a transformer rule that transforms the input event.Message.
+// The input event.Message might be updated by the rule.
 type Rule func(event.Message) event.Message
 
 func (r Rule) Transform(in event.Message) event.Message {

--- a/handlers/transformer/rules_test.go
+++ b/handlers/transformer/rules_test.go
@@ -1,6 +1,7 @@
 package transformer_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,10 +37,13 @@ func TestRenameSourcesRule(t *testing.T) {
 	}
 
 	for inputSource, expectedTransformedSource := range inputSourceToTransformedSource {
-		transformed := renameSources.Transform(event.NewMessage(key, inputSource, content))
-		assert.Equal(t, key, transformed.GetKey())
-		assert.Equal(t, expectedTransformedSource, transformed.GetSource())
-		assert.Equal(t, content, transformed.GetContent())
+		testName := fmt.Sprintf("transform %s", inputSource)
+		t.Run(testName, func(t *testing.T) {
+			transformed := renameSources.Transform(event.NewMessage(key, inputSource, content))
+			assert.Equal(t, key, transformed.GetKey())
+			assert.Equal(t, expectedTransformedSource, transformed.GetSource())
+			assert.Equal(t, content, transformed.GetContent())
+		})
 	}
 }
 
@@ -53,9 +57,12 @@ func TestEraseContentFromSources(t *testing.T) {
 	}
 
 	for inputSource, expectedTransformedContent := range inputSourceToTransformedContent {
-		transformed := eraseContentFromSources.Transform(event.NewMessage(key, inputSource, content))
-		assert.Equal(t, key, transformed.GetKey())
-		assert.Equal(t, inputSource, transformed.GetSource())
-		assert.Equal(t, expectedTransformedContent, transformed.GetContent())
+		testName := fmt.Sprintf("transform %s", inputSource)
+		t.Run(testName, func(t *testing.T) {
+			transformed := eraseContentFromSources.Transform(event.NewMessage(key, inputSource, content))
+			assert.Equal(t, key, transformed.GetKey())
+			assert.Equal(t, inputSource, transformed.GetSource())
+			assert.Equal(t, expectedTransformedContent, transformed.GetContent())
+		})
 	}
 }

--- a/handlers/transformer/transformer.go
+++ b/handlers/transformer/transformer.go
@@ -7,7 +7,8 @@ import (
 	"github.com/lukecold/event-driver/handlers"
 )
 
-// transformer transforms the input with the given rules
+// transformer implements handlers.Handler that transforms the input with the given rules.
+// The input event.Message might be updated by the transformer.
 type transformer struct {
 	rule Rule
 }

--- a/handlers/transformer/transformer_test.go
+++ b/handlers/transformer/transformer_test.go
@@ -2,6 +2,7 @@ package transformer_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,13 +33,16 @@ func TestTransformer(t *testing.T) {
 	}
 
 	for inputSource, expectedTransformedEvent := range inputSourceToTransformedEvent {
-		ctx := context.TODO()
-		ctrl := gomock.NewController(t)
-		next := mocks.NewMockCallNext(ctrl)
-		next.EXPECT().Call(ctx, expectedTransformedEvent)
+		testName := fmt.Sprintf("transform %s", inputSource)
+		t.Run(testName, func(t *testing.T) {
+			ctx := context.TODO()
+			ctrl := gomock.NewController(t)
+			next := mocks.NewMockCallNext(ctrl)
+			next.EXPECT().Call(ctx, expectedTransformedEvent)
 
-		message := event.NewMessage(key, inputSource, content)
-		err := eventMapper.Process(ctx, message, next)
-		assert.NoError(t, err)
+			message := event.NewMessage(key, inputSource, content)
+			err := eventMapper.Process(ctx, message, next)
+			assert.NoError(t, err)
+		})
 	}
 }


### PR DESCRIPTION


## Checklist
- [x] I've run and passed the [`pre-commit`](https://pre-commit.com).
- [x] I've put adequate descriptions that explains why this change is made.

## Description

This PR implements the `joiner.Condition` that accommodates the event joining in the pipeline.

One can create a new `joiner` handler with conditions, following
```golang
condition := joiner.MatchAll("source1").
    And(joiner.MatchAny("source2", "source3")).
    OR(joiner.MatchAll("source4", "source5"), joiner.MatchNone("source4"))
eventStore := storage.NewGoogleCloudEventStore()
handler := joiner.New(condition, eventStore)
```