### PR TITLE
feat: Add syntactic sugar of skip on conflict

### DIFF
--- a/handlers/cache/cache.go
+++ b/handlers/cache/cache.go
@@ -8,12 +8,6 @@ import (
 	"github.com/lukecold/event-driver/storage"
 )
 
-// ConflictResolver implements handlers.Handler that resolves the case
-// when the input matches an existing record in the cache.
-type ConflictResolver interface {
-	Resolve(ctx context.Context, in *event.Message, next handlers.CallNext) error
-}
-
 // cache persists the input in a storage, and let user decide what to do in case of a cache hit.
 type cache struct {
 	storage          storage.EventStore

--- a/handlers/cache/conflict_resolver.go
+++ b/handlers/cache/conflict_resolver.go
@@ -1,0 +1,25 @@
+package cache
+
+import (
+	"context"
+
+	"github.com/lukecold/event-driver/event"
+	"github.com/lukecold/event-driver/handlers"
+)
+
+// ConflictResolver implements handlers.Handler that resolves the case
+// when the input matches an existing record in the cache.
+type ConflictResolver interface {
+	Resolve(ctx context.Context, in *event.Message, next handlers.CallNext) error
+}
+
+type skipOnConflict struct{}
+
+func (s *skipOnConflict) Resolve(_ context.Context, _ *event.Message, _ handlers.CallNext) error {
+	return nil
+}
+
+// SkipOnConflict returns a ConflictResolver that simply skips the following handlers in pipeline on conflict.
+func SkipOnConflict() ConflictResolver {
+	return &skipOnConflict{}
+}

--- a/handlers/cache/conflict_resolver_test.go
+++ b/handlers/cache/conflict_resolver_test.go
@@ -1,0 +1,33 @@
+package cache_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lukecold/event-driver/event"
+	"github.com/lukecold/event-driver/handlers/cache"
+	"github.com/lukecold/event-driver/mocks"
+	"github.com/lukecold/event-driver/storage"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSkipOnConflict(t *testing.T) {
+	ctx := context.TODO()
+	input1 := event.NewMessage("key", "source", "content1")
+	input2 := event.NewMessage("key", "source", "content2")
+
+	skipOnConflict := cache.SkipOnConflict()
+	ctrl := gomock.NewController(t)
+	callNext := mocks.NewMockCallNext(ctrl)
+	eventStore := storage.NewInMemoryStore()
+
+	// callNext got triggered on input1, but skipped on input2
+	callNext.EXPECT().Call(ctx, input1)
+
+	handler := cache.New(eventStore, skipOnConflict)
+	err := handler.Process(ctx, input1, callNext)
+	assert.NoError(t, err)
+	err = handler.Process(ctx, input2, callNext)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION


## Checklist
- [x] I've run and passed the [`pre-commit`](https://pre-commit.com).
- [x] I've put adequate descriptions that explains why this change is made.

## Description
This PR is to add an implementation of `ConflictResolver` that simply skips the following handlers on conflict.