### PR TITLE
ci: Exclude test and mock files from SonarCloud scan

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,3 +5,6 @@ sonar.projectKey=lukecold_event-driver
 # in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/
 sonar.sources=.
 sonar.go.coverage.reportPaths=./cover.out
+
+sonar.exclusions=**/*_test.go,mocks/**
+sonar.cpd.exclusions=**/*_test.go,mocks/**


### PR DESCRIPTION
## Checklist
- [x] I've run and passed the [`pre-commit`](https://pre-commit.com).
- [x] I've put adequate descriptions that explains why this change is made.

## Description
The test and mock files got included in the SonarCloud scan automatically, which resulted in a false report on low test coverage and duplicate code.