### PR TITLE
feat: Make pipeline respect the context timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Event Driver
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/lukecold/event-driver.svg)](https://pkg.go.dev/github.com/lukecold/event-driver)
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/lukecold/event-driver)
 [![Go Project Version](https://badge.fury.io/go/github.com%2Flukecold%2Fevent-driver.svg)](https://badge.fury.io/go/github.com%2Flukecold%2Fevent-driver)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=lukecold_event-driver&metric=alert_status)](https://sonarcloud.io/dashboard?id=lukecold_event-driver)
@@ -101,7 +102,8 @@ This service needs to
    myPipeline := pipeline.New().
        WithNextHandler(eraseContentOfEvent1Handler). // remove the content of event1 before joining
        WithNextHandler(myJoiner).                    // join all events of the same key into a single message
-       WithNextHandler(idempotencyHandler)           // check for idempotency after a joint message is formed
+       WithNextHandler(idempotencyHandler).          // check for idempotency after a joint message is formed
+       WithNextHandler(businessHandler)              // handles the business logic
    ```
 7. Start serving traffic!
    ```golang

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -2,14 +2,23 @@ package pipeline
 
 import (
 	"context"
+	"errors"
+	"log"
 
 	"github.com/lukecold/event-driver/event"
 	"github.com/lukecold/event-driver/handlers"
 )
 
 type Pipeline interface {
+	// WithNextHandler append a handler to the end of the pipeline.
 	WithNextHandler(handler handlers.Handler) Pipeline
-	Run(ctx context.Context, in *event.Message) error
+	// Process executes the handlers in the pipeline in order.
+	// If using customized handlers, please make sure next#Call is executed if it's not the last handler.
+	// Process respects context.Deadline, and would return a timeout error immediately when deadline is reached.
+	// Please note that the handler may still keep running until it's terminated by itself or
+	// when the main goroutine (usually the service) is terminated.
+	// One is responsible to make their customized handlers handle timeouts gracefully, to prevent resource leak.
+	Process(ctx context.Context, in *event.Message) error
 }
 
 type pipeline struct {
@@ -34,15 +43,33 @@ func (n next) Call(ctx context.Context, in *event.Message) error {
 	return n(ctx, in)
 }
 
-func (p *pipeline) Run(pipelineContext context.Context, pipelineInput *event.Message) error {
-	processor := next(func(ctx context.Context, in *event.Message) (_ error) {
-		return
+func (p *pipeline) Process(ctx context.Context, in *event.Message) error {
+	process := next(func(_ context.Context, _ *event.Message) error {
+		return nil
 	})
 	for i := len(p.handlers) - 1; i >= 0; i-- {
-		processor = func(ctx context.Context, in *event.Message) error {
-			return p.handlers[i].Process(ctx, in, processor)
+		index := i
+		processNext := process
+		process = func(handlerCtx context.Context, message *event.Message) error {
+			errorChan := make(chan error)
+			go func(index int, errorChan chan error) {
+				errorChan <- p.handlers[index].Process(handlerCtx, message, processNext)
+			}(index, errorChan)
+
+			select {
+			case gotError := <-errorChan:
+				if gotError != nil {
+					log.Printf("[ERROR] handler at index %d failed with error %v", index, gotError)
+				}
+
+				return gotError
+			case <-handlerCtx.Done():
+				log.Printf("[ERROR] handler at index %d timed out", index)
+
+				return errors.New("pipeline timed out")
+			}
 		}
 	}
 
-	return processor(pipelineContext, pipelineInput)
+	return process(ctx, in)
 }

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -1,0 +1,104 @@
+package pipeline_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lukecold/event-driver/event"
+	"github.com/lukecold/event-driver/handlers"
+	"github.com/lukecold/event-driver/pipeline"
+)
+
+type testHandler struct {
+	processTime time.Duration
+	err         error
+}
+
+func createHandler(processTime time.Duration) handlers.Handler {
+	return &testHandler{
+		processTime: processTime,
+		err:         nil,
+	}
+}
+
+func createFailedHandler(processTime time.Duration, err error) handlers.Handler {
+	return &testHandler{
+		processTime: processTime,
+		err:         err,
+	}
+}
+
+func (h *testHandler) Process(ctx context.Context, in *event.Message, next handlers.CallNext) error {
+	time.Sleep(h.processTime)
+	if h.err != nil {
+		return h.err
+	}
+
+	return next.Call(ctx, in)
+}
+
+func TestPipelineFail(t *testing.T) {
+	t.Run("happy case", func(t *testing.T) {
+		testPipeline := pipeline.New().
+			WithNextHandler(createHandler(time.Nanosecond)).
+			WithNextHandler(createHandler(time.Nanosecond))
+
+		err := testPipeline.Process(context.Background(), nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("stop processing when handler failed", func(t *testing.T) {
+		expectedError := errors.New("fail")
+		testPipeline := pipeline.New().
+			WithNextHandler(createHandler(time.Nanosecond)).
+			WithNextHandler(createFailedHandler(time.Nanosecond, expectedError)).
+			WithNextHandler(createFailedHandler(time.Nanosecond, errors.New("other error")))
+
+		err := testPipeline.Process(context.Background(), nil)
+		assert.Equal(t, expectedError, err)
+	})
+}
+
+func TestPipelineTimeout(t *testing.T) {
+	ctx := context.Background()
+	testPipeline := pipeline.New().
+		WithNextHandler(createHandler(10 * time.Millisecond)).
+		WithNextHandler(createHandler(100 * time.Millisecond))
+
+	type TestCase struct {
+		createCtx     func() (context.Context, context.CancelFunc)
+		expectedError error
+	}
+	testCases := map[string]TestCase{
+		"timeout at index 0": {
+			createCtx: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(ctx, time.Millisecond)
+			},
+			expectedError: errors.New("pipeline timed out"),
+		},
+		"timeout at index 1": {
+			createCtx: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(ctx, 101*time.Millisecond)
+			},
+			expectedError: errors.New("pipeline timed out"),
+		},
+		"finish within timeout": {
+			createCtx: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(ctx, 200*time.Millisecond)
+			},
+			expectedError: nil,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			ctxWithTimeout, _ := testCase.createCtx()
+			actualError := testPipeline.Process(ctxWithTimeout, nil)
+			assert.Equal(t, testCase.expectedError, actualError)
+		})
+	}
+}


### PR DESCRIPTION
## Checklist
- [x] I've run and passed `make commit` (requires [`pre-commit`](https://pre-commit.com) command been installed).
- [x] I've put adequate descriptions that explains why this change is made.

## Description
This PR makes the `pipeline.Pipeline` respect `context.Deadline`. 

One could use this feature by passing `context.WithTimeout(parentContext, timeoutDuration)` to `pipeline#Process`, then `pipeline#Process` would return a timeout error immediately when deadline is reached. 

**Please note that the handler may still keep running until it's terminated by itself or when the main goroutine (usually the service) is terminated. One is responsible to make their customized handlers handle timeouts gracefully, to prevent resource leak.**

Also updated the `pipeline.Run` to `pipeline.Process`, since `#Run` gives users an incorrect idea that this may start serving live traffic, rather than just processes one input message.