### PR TITLE
feat: GCS event store support grouping storage with folders

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: detect-aws-credentials
         args: [ '--allow-missing-credentials' ]
   - repo: git@github.com:golangci/golangci-lint.git
-    rev: v1.56.1
+    rev: v1.57.2
     hooks:
       - id: golangci-lint
   - repo: git@github.com:TekWizely/pre-commit-golang.git

--- a/extensions/google-cloud/storage/gcs_event_store/gcs_config.go
+++ b/extensions/google-cloud/storage/gcs_event_store/gcs_config.go
@@ -15,6 +15,7 @@ const (
 
 type GCSConfig struct {
 	Bucket  string
+	Folder  *string
 	Timeout Timeout
 }
 
@@ -31,6 +32,12 @@ func Config(bucket string) *GCSConfig {
 			Operation: make(map[Operation]time.Duration),
 		},
 	}
+}
+
+func (c *GCSConfig) WithFolder(folder string) *GCSConfig {
+	c.Folder = &folder
+
+	return c
 }
 
 func (c *GCSConfig) WithTimeout(timeout Timeout) *GCSConfig {

--- a/extensions/google-cloud/storage/gcs_event_store/gcs_event_store_test.go
+++ b/extensions/google-cloud/storage/gcs_event_store/gcs_event_store_test.go
@@ -24,41 +24,86 @@ const (
 )
 
 func TestGCSEventStore(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		fmt.Println(r.URL.Path)
-		switch {
-		case strings.HasPrefix(r.URL.Path, "/upload/"): // write operation
-			body, err := io.ReadAll(r.Body)
-			assert.NoError(t, err)
-			// assert that bucket, key, source, and content match
-			assert.Contains(t, string(body), fmt.Sprintf(`{"bucket":"bucket","name":"%s/%s"}`, key, source))
-			assert.Contains(t, string(body), content)
-			w.Write([]byte("{}"))
-		case strings.HasPrefix(r.URL.Path, fmt.Sprintf("/bucket/%s/%s", key, source)): // read operation
-			w.Write([]byte(content))
-		case strings.HasPrefix(r.URL.Path, "/storage/v1/b/bucket/o"): // list operation
-			w.Write([]byte(`{
+	t.Run("with folder prefix", func(t *testing.T) {
+		folderName := "folder-name"
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Println(r.URL.Path)
+			switch {
+			case strings.HasPrefix(r.URL.Path, "/upload/"): // write operation
+				body, err := io.ReadAll(r.Body)
+				assert.NoError(t, err)
+				// assert that bucket, key, source, and content match
+				assert.Contains(t, string(body), fmt.Sprintf(`{"bucket":"bucket","name":"%s/%s/%s"}`, folderName, key, source))
+				assert.Contains(t, string(body), content)
+				w.Write([]byte("{}"))
+			case strings.HasPrefix(r.URL.Path, fmt.Sprintf("/bucket/%s/%s/%s", folderName, key, source)): // read operation
+				w.Write([]byte(content))
+			case strings.HasPrefix(r.URL.Path, "/storage/v1/b/bucket/o"): // list operation
+				w.Write([]byte(`{
+				"kind":"storage#objects",
+				"items":[{"kind":"storage#object","name":"folderName/key/source1"},{"kind":"storage#object","name":"folderName/key/source2"}]
+			}`))
+			}
+		}))
+		defer server.Close()
+
+		os.Setenv("STORAGE_EMULATOR_HOST", server.URL)
+
+		config := gcs_event_store.Config("bucket").WithFolder(folderName)
+		eventStore, err := gcs_event_store.New(context.TODO(), config, option.WithoutAuthentication())
+		assert.NoError(t, err)
+
+		err = eventStore.Persist(context.TODO(), key, source, content)
+		assert.NoError(t, err)
+
+		message, err := eventStore.LookUp(context.TODO(), key, source)
+		assert.NoError(t, err)
+		assert.Equal(t, event.NewMessage(key, source, content), message)
+
+		messageArray, err := eventStore.LookUpByKey(context.TODO(), key)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(messageArray))
+	})
+
+	t.Run("without folder prefix", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Println(r.URL.Path)
+			switch {
+			case strings.HasPrefix(r.URL.Path, "/upload/"): // write operation
+				body, err := io.ReadAll(r.Body)
+				assert.NoError(t, err)
+				// assert that bucket, key, source, and content match
+				assert.Contains(t, string(body), fmt.Sprintf(`{"bucket":"bucket","name":"%s/%s"}`, key, source))
+				assert.Contains(t, string(body), content)
+				w.Write([]byte("{}"))
+			case strings.HasPrefix(r.URL.Path, fmt.Sprintf("/bucket/%s/%s", key, source)): // read operation
+				w.Write([]byte(content))
+			case strings.HasPrefix(r.URL.Path, "/storage/v1/b/bucket/o"): // list operation
+				w.Write([]byte(`{
 				"kind":"storage#objects",
 				"items":[{"kind":"storage#object","name":"key/source1"},{"kind":"storage#object","name":"key/source2"}]
 			}`))
-		}
-	}))
-	defer server.Close()
+			}
+		}))
+		defer server.Close()
 
-	os.Setenv("STORAGE_EMULATOR_HOST", server.URL)
-	config := gcs_event_store.Config("bucket")
-	eventStore, err := gcs_event_store.New(context.TODO(), config, option.WithoutAuthentication())
-	assert.NoError(t, err)
+		os.Setenv("STORAGE_EMULATOR_HOST", server.URL)
 
-	err = eventStore.Persist(context.TODO(), key, source, content)
-	assert.NoError(t, err)
+		config := gcs_event_store.Config("bucket")
+		eventStore, err := gcs_event_store.New(context.TODO(), config, option.WithoutAuthentication())
+		assert.NoError(t, err)
 
-	message, err := eventStore.LookUp(context.TODO(), key, source)
-	assert.NoError(t, err)
-	assert.Equal(t, event.NewMessage(key, source, content), message)
+		err = eventStore.Persist(context.TODO(), key, source, content)
+		assert.NoError(t, err)
 
-	messageArray, err := eventStore.LookUpByKey(context.TODO(), key)
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(messageArray))
+		message, err := eventStore.LookUp(context.TODO(), key, source)
+		assert.NoError(t, err)
+		assert.Equal(t, event.NewMessage(key, source, content), message)
+
+		messageArray, err := eventStore.LookUpByKey(context.TODO(), key)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(messageArray))
+	})
 }


### PR DESCRIPTION

## Checklist
- [x] I've run and passed `make commit` (requires [`pre-commit`](https://pre-commit.com) command been installed).
- [x] I've put adequate descriptions that explains why this change is made.

## Description
Use case scenario: Multiple services share the same GCS bucket for input joiner / cache, in order to reduce the effort to configure the buckets and IAM separately, and requires storage isolation among the services.

This PR added support to group the storage with folders, so that the storage could be:
- service-a/inputs/key/source
- service-a/cache/key
- service-b/inputs/key/source 
...
