### PR TITLE
feat: Add logging in the handlers

### DIFF
--- a/handlers/cache/cache.go
+++ b/handlers/cache/cache.go
@@ -5,26 +5,29 @@ import (
 
 	"github.com/lukecold/event-driver/event"
 	"github.com/lukecold/event-driver/handlers"
+	"github.com/lukecold/event-driver/log"
 	"github.com/lukecold/event-driver/storage"
 )
 
 // cache persists the input in a storage, and let user decide what to do in case of a cache hit.
 type cache struct {
-	conflictResolver ConflictResolver
-	keyExtractor     KeyExtractor
-	storage          storage.EventStore
+	cacheKeyExtractor KeyExtractor
+	conflictResolver  ConflictResolver
+	logger            *log.Logger
+	storage           storage.EventStore
 }
 
 func New(storage storage.EventStore) *cache {
 	return &cache{
-		conflictResolver: SkipOnConflict(),
-		keyExtractor:     ExtractMessageKey(),
-		storage:          storage,
+		cacheKeyExtractor: GetMessageKey(),
+		conflictResolver:  SkipOnConflict(),
+		logger:            log.New("cache"),
+		storage:           storage,
 	}
 }
 
 func (c *cache) WithKeyExtractor(keyExtractor KeyExtractor) *cache {
-	c.keyExtractor = keyExtractor
+	c.cacheKeyExtractor = keyExtractor
 
 	return c
 }
@@ -35,26 +38,41 @@ func (c *cache) WithConflictResolver(conflictResolver ConflictResolver) *cache {
 	return c
 }
 
+func (c *cache) Verbose() *cache {
+	c.logger.Verbose()
+
+	return c
+}
+
 func (c *cache) Process(ctx context.Context, in *event.Message, next handlers.CallNext) error {
-	key, err := c.keyExtractor.Extract(in)
+	key, err := c.cacheKeyExtractor.Extract(in)
 	if err != nil {
+		c.logger.Error("failed to extract cache key for message_key=%s", in.GetKey())
+
 		return err
 	}
 	source := in.GetSource()
 	message, err := c.storage.LookUp(ctx, key, source)
 	if err != nil {
+		c.logger.Error("failed to look up message with cache_key=%s", key)
+
 		return err
 	}
 	// cache hit
 	if message != nil {
+		c.logger.Info("cache hit on cache_key=%s", key)
+
 		return c.conflictResolver.Resolve(ctx, message, next)
 	}
 
 	// persist input message by key & source
 	err = c.storage.Persist(ctx, key, source, in.GetContent())
 	if err != nil {
+		c.logger.Error("failed to persist message with cache_key=%s, source=%s", key, in.GetSource())
+
 		return err
 	}
+	c.logger.Debug("cache not hit on cache_key=%s", key)
 
 	return next.Call(ctx, in)
 }

--- a/handlers/cache/cache_test.go
+++ b/handlers/cache/cache_test.go
@@ -22,7 +22,7 @@ func TestCache(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		conflictResolver := mocks.NewMockConflictResolver(ctrl)
-		keyExtractor := cache.ExtractMessageKey()
+		keyExtractor := cache.GetMessageKey()
 		callNext := mocks.NewMockCallNext(ctrl)
 		eventStore := storage.NewInMemoryStore()
 
@@ -45,7 +45,7 @@ func TestCache(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		conflictResolver := mocks.NewMockConflictResolver(ctrl)
-		keyExtractor := cache.ExtractMessageKey()
+		keyExtractor := cache.GetMessageKey()
 		callNext := mocks.NewMockCallNext(ctrl)
 		eventStore := storage.NewInMemoryStore()
 
@@ -67,7 +67,7 @@ func TestCache(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		conflictResolver := mocks.NewMockConflictResolver(ctrl)
-		keyExtractor := cache.ExtractMessageKey()
+		keyExtractor := cache.GetMessageKey()
 		callNext := mocks.NewMockCallNext(ctrl)
 		eventStore := storage.NewInMemoryStore()
 
@@ -89,7 +89,7 @@ func TestCache(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		conflictResolver := mocks.NewMockConflictResolver(ctrl)
-		keyExtractor := cache.ExtractMessageKey()
+		keyExtractor := cache.GetMessageKey()
 		callNext := mocks.NewMockCallNext(ctrl)
 		eventStore := storage.NewInMemoryStore()
 
@@ -108,7 +108,7 @@ func TestCache(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		conflictResolver := mocks.NewMockConflictResolver(ctrl)
-		keyExtractor := cache.ExtractMessageKey()
+		keyExtractor := cache.GetMessageKey()
 		callNext := mocks.NewMockCallNext(ctrl)
 		eventStore := mocks.NewMockEventStore(ctrl)
 
@@ -128,7 +128,7 @@ func TestCache(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		conflictResolver := mocks.NewMockConflictResolver(ctrl)
-		keyExtractor := cache.ExtractMessageKey()
+		keyExtractor := cache.GetMessageKey()
 		callNext := mocks.NewMockCallNext(ctrl)
 		eventStore := mocks.NewMockEventStore(ctrl)
 

--- a/handlers/cache/cache_test.go
+++ b/handlers/cache/cache_test.go
@@ -26,12 +26,13 @@ func TestCache(t *testing.T) {
 		callNext := mocks.NewMockCallNext(ctrl)
 		eventStore := storage.NewInMemoryStore()
 
-		callNext.EXPECT().Call(gomock.Any(), gomock.Any()).AnyTimes()
+		callNext.EXPECT().Call(gomock.Any(), gomock.Any())
 		conflictResolver.EXPECT().Resolve(ctx, input1, callNext).Times(1) // trigger conflictResolver when cache hit
 
 		handler := cache.New(eventStore).
 			WithConflictResolver(conflictResolver).
-			WithKeyExtractor(keyExtractor)
+			WithKeyExtractor(keyExtractor).
+			Verbose()
 		err := handler.Process(ctx, input1, callNext)
 		assert.NoError(t, err)
 		err = handler.Process(ctx, input2, callNext)
@@ -49,7 +50,7 @@ func TestCache(t *testing.T) {
 		callNext := mocks.NewMockCallNext(ctrl)
 		eventStore := storage.NewInMemoryStore()
 
-		callNext.EXPECT().Call(gomock.Any(), gomock.Any()).AnyTimes()
+		callNext.EXPECT().Call(gomock.Any(), gomock.Any()).Times(2)
 
 		handler := cache.New(eventStore).
 			WithConflictResolver(conflictResolver).

--- a/handlers/cache/key_extractor.go
+++ b/handlers/cache/key_extractor.go
@@ -8,13 +8,13 @@ type KeyExtractor interface {
 	Extract(*event.Message) (string, error)
 }
 
-type extractMessageKey struct{}
+type getMessageKey struct{}
 
-func (k *extractMessageKey) Extract(in *event.Message) (string, error) {
+func (k *getMessageKey) Extract(in *event.Message) (string, error) {
 	return in.GetKey(), nil
 }
 
-// ExtractMessageKey returns a KeyExtractor that simply gets the member value "key" from the message.
-func ExtractMessageKey() KeyExtractor {
-	return &extractMessageKey{}
+// GetMessageKey returns a CacheKeyExtractor that simply gets the member value "key" from the message.
+func GetMessageKey() KeyExtractor {
+	return &getMessageKey{}
 }

--- a/handlers/cache/key_extractor_test.go
+++ b/handlers/cache/key_extractor_test.go
@@ -39,7 +39,7 @@ func TestKeyExtractor(t *testing.T) {
 		input1 := event.NewMessage("key", "source", "content1")
 		input2 := event.NewMessage("key", "source", "content2")
 
-		keyExtractor := cache.ExtractMessageKey()
+		keyExtractor := cache.GetMessageKey()
 		ctrl := gomock.NewController(t)
 		callNext := mocks.NewMockCallNext(ctrl)
 		eventStore := storage.NewInMemoryStore()

--- a/handlers/joiner/joiner_test.go
+++ b/handlers/joiner/joiner_test.go
@@ -29,7 +29,7 @@ func TestJoiner(t *testing.T) {
 		expectedMessage := event.NewMessage("key", "composed-event", `{"source1":"content1","source2":"content2"}`)
 		callNext.EXPECT().Call(gomock.Any(), expectedMessage).AnyTimes()
 
-		handler := joiner.New(condition, eventStore)
+		handler := joiner.New(condition, eventStore).Verbose()
 		err := handler.Process(ctx, input1, callNext)
 		assert.NoError(t, err)
 		err = handler.Process(ctx, input2, callNext)

--- a/handlers/transformer/transformer.go
+++ b/handlers/transformer/transformer.go
@@ -5,12 +5,14 @@ import (
 
 	"github.com/lukecold/event-driver/event"
 	"github.com/lukecold/event-driver/handlers"
+	"github.com/lukecold/event-driver/log"
 )
 
 // transformer implements handlers.Handler that transforms the input with the given rules.
 // The input event.Message might be updated by the transformer.
 type transformer struct {
-	rule Rule
+	logger *log.Logger
+	rule   Rule
 }
 
 func New(rules ...Rule) *transformer {
@@ -20,7 +22,8 @@ func New(rules ...Rule) *transformer {
 	}
 
 	return &transformer{
-		rule: composeRule,
+		logger: log.New("transformer"),
+		rule:   composeRule,
 	}
 }
 
@@ -32,8 +35,15 @@ func (m *transformer) WithRules(rules ...Rule) *transformer {
 	return m
 }
 
+func (m *transformer) Verbose() *transformer {
+	m.logger.Verbose()
+
+	return m
+}
+
 func (m *transformer) Process(ctx context.Context, in *event.Message, next handlers.CallNext) error {
 	transformed := m.rule.Transform(in)
+	m.logger.Debug("transformed message for key=%s, source=%s", in.GetKey(), in.GetSource())
 
 	return next.Call(ctx, transformed)
 }

--- a/handlers/transformer/transformer_test.go
+++ b/handlers/transformer/transformer_test.go
@@ -22,7 +22,8 @@ func TestTransformer(t *testing.T) {
 	eraseContentFromSource := transformer.EraseContentFromSources(source)
 	eraseContentFromSource1And2 := transformer.EraseContentFromSources("source1", "source2")
 	eventMapper := transformer.New(renameSources, eraseContentFromSource).
-		WithRules(eraseContentFromSource1And2)
+		WithRules(eraseContentFromSource1And2).
+		Verbose()
 
 	inputSourceToTransformedEvent := map[string]*event.Message{
 		"alias1":  event.NewMessage(key, source, ""),

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,0 +1,52 @@
+package log
+
+import (
+	"log"
+)
+
+type Level string
+
+const (
+	DEBUG Level = "DEBUG"
+	INFO  Level = "INFO"
+	WARN  Level = "WARN"
+	ERROR Level = "ERROR"
+)
+
+type Logger struct {
+	domain  string
+	verbose bool
+}
+
+func New(domain string) *Logger {
+	return &Logger{
+		domain: domain,
+	}
+}
+
+func (l *Logger) Verbose() {
+	l.verbose = true
+}
+
+func (l *Logger) Debug(message string, args ...any) {
+	l.Printf(DEBUG, message, args...)
+}
+
+func (l *Logger) Info(message string, args ...any) {
+	l.Printf(INFO, message, args...)
+}
+
+func (l *Logger) Warn(message string, args ...any) {
+	l.Printf(WARN, message, args...)
+}
+
+func (l *Logger) Error(message string, args ...any) {
+	l.Printf(ERROR, message, args...)
+}
+
+func (l *Logger) Printf(logLevel Level, message string, args ...any) {
+	if !l.verbose && logLevel == DEBUG {
+		return
+	}
+	log.Printf("[%s] %s: "+message, append([]any{logLevel, l.domain}, args...)...)
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,5 +6,5 @@ sonar.projectKey=lukecold_event-driver
 sonar.sources=.
 sonar.go.coverage.reportPaths=./cover.out
 
-sonar.exclusions=**/*_test.go,mocks/**
-sonar.cpd.exclusions=**/*_test.go,mocks/**
+sonar.exclusions=**/*_test.go,mocks/**,log/**
+sonar.cpd.exclusions=**/*_test.go,mocks/**,log/**


### PR DESCRIPTION
## Checklist
- [x] I've run and passed `make commit` (requires [`pre-commit`](https://pre-commit.com) command been installed).
- [x] I've put adequate descriptions that explains why this change is made.

## Description

Issue: https://github.com/lukecold/event-driver/issues/27

**Motivation**
- The errors have to go through multiple layers until they eventually get surfaced to the caller, at which point it's harder to locate where the error originated from.
- Callers may also want to record metrics, such as error rate and latency, on the built-in handlers.

**Changes**
- Added logs in the built-in handlers
- Added option to make the logs verbose to get more details
- Added support to use a key other than the message key for the cache