### PR TITLE
fix(extensions/google-cloud): GCSEventStore should return null message when object is not found

### DIFF
--- a/extensions/google-cloud/storage/gcs_event_store/gcs_event_store.go
+++ b/extensions/google-cloud/storage/gcs_event_store/gcs_event_store.go
@@ -60,6 +60,9 @@ func (g *GCSEventStore) LookUp(ctx context.Context, key, source string) (*event.
 	if err != nil {
 		return nil, err
 	}
+	if content == nil {
+		return nil, nil
+	}
 
 	return event.NewMessage(key, source, string(content)), nil
 }


### PR DESCRIPTION
## Checklist
- [x] I've run and passed `make commit` (requires [`pre-commit`](https://pre-commit.com) command been installed).
- [x] I've put adequate descriptions that explains why this change is made.

## Description

The function `GCSEventStore#LookUp` returns an empty message when the object is not found. This caused the caller mistakenly marked the object "found".

This PR changes it to return a null pointer instead.