### PR TITLE
feat: EventStore support looking up sources by key

### DIFF
--- a/mocks/mock_event_storage.go
+++ b/mocks/mock_event_storage.go
@@ -40,6 +40,21 @@ func (m *MockEventStore) EXPECT() *MockEventStoreMockRecorder {
 	return m.recorder
 }
 
+// ListSourcesByKey mocks base method.
+func (m *MockEventStore) ListSourcesByKey(arg0 context.Context, arg1 string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSourcesByKey", arg0, arg1)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSourcesByKey indicates an expected call of ListSourcesByKey.
+func (mr *MockEventStoreMockRecorder) ListSourcesByKey(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSourcesByKey", reflect.TypeOf((*MockEventStore)(nil).ListSourcesByKey), arg0, arg1)
+}
+
 // LookUp mocks base method.
 func (m *MockEventStore) LookUp(arg0 context.Context, arg1, arg2 string) (*event.Message, error) {
 	m.ctrl.T.Helper()

--- a/storage/event_store.go
+++ b/storage/event_store.go
@@ -8,7 +8,8 @@ import (
 
 // EventStore persists an event by key & source, and looks up an event by key+source, or a collection of events by key.
 type EventStore interface {
-	Persist(ctx context.Context, key, source, content string) error
+	ListSourcesByKey(ctx context.Context, key string) ([]string, error)
 	LookUp(ctx context.Context, key, source string) (*event.Message, error)
 	LookUpByKey(ctx context.Context, key string) ([]*event.Message, error)
+	Persist(ctx context.Context, key, source, content string) error
 }

--- a/storage/in_memory_store.go
+++ b/storage/in_memory_store.go
@@ -15,16 +15,17 @@ func NewInMemoryStore() *InMemoryStore {
 	return &inMemoryStore
 }
 
-func (i *InMemoryStore) Persist(ctx context.Context, key, source, content string) error {
-	if _, isKeyExist := (*i)[key]; !isKeyExist {
-		(*i)[key] = make(map[string]string)
+func (i *InMemoryStore) ListSourcesByKey(_ context.Context, key string) ([]string, error) {
+	results := (*i)[key]
+	sources := make([]string, 0, len(results))
+	for source := range results {
+		sources = append(sources, source)
 	}
-	(*i)[key][source] = content
 
-	return nil
+	return sources, nil
 }
 
-func (i *InMemoryStore) LookUp(ctx context.Context, key, source string) (*event.Message, error) {
+func (i *InMemoryStore) LookUp(_ context.Context, key, source string) (*event.Message, error) {
 	content, isHit := (*i)[key][source]
 	if !isHit {
 		return nil, nil
@@ -33,7 +34,7 @@ func (i *InMemoryStore) LookUp(ctx context.Context, key, source string) (*event.
 	return event.NewMessage(key, source, content), nil
 }
 
-func (i *InMemoryStore) LookUpByKey(ctx context.Context, key string) ([]*event.Message, error) {
+func (i *InMemoryStore) LookUpByKey(_ context.Context, key string) ([]*event.Message, error) {
 	results := (*i)[key]
 	messages := make([]*event.Message, 0, len(results))
 	for source, content := range results {
@@ -41,4 +42,13 @@ func (i *InMemoryStore) LookUpByKey(ctx context.Context, key string) ([]*event.M
 	}
 
 	return messages, nil
+}
+
+func (i *InMemoryStore) Persist(_ context.Context, key, source, content string) error {
+	if _, isKeyExist := (*i)[key]; !isKeyExist {
+		(*i)[key] = make(map[string]string)
+	}
+	(*i)[key][source] = content
+
+	return nil
 }

--- a/storage/in_memory_store_test.go
+++ b/storage/in_memory_store_test.go
@@ -1,0 +1,70 @@
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lukecold/event-driver/event"
+	"github.com/lukecold/event-driver/storage"
+)
+
+const (
+	key1    = "key1"
+	key2    = "key2"
+	source1 = "source1"
+	source2 = "source2"
+)
+
+func TestNewInMemoryStore(t *testing.T) {
+	inMemoryStore := storage.NewInMemoryStore()
+	ctx := context.TODO()
+
+	// persist
+	err := inMemoryStore.Persist(ctx, key1, source1, "content1-1")
+	assert.NoError(t, err)
+	err = inMemoryStore.Persist(ctx, key1, source2, "content1-2")
+	assert.NoError(t, err)
+	err = inMemoryStore.Persist(ctx, key2, source1, "content2-1")
+	assert.NoError(t, err)
+
+	// list sources by key
+	sources, err := inMemoryStore.ListSourcesByKey(ctx, key1)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{source1, source2}, sources)
+	sources, err = inMemoryStore.ListSourcesByKey(ctx, key2)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{source1}, sources)
+	sources, err = inMemoryStore.ListSourcesByKey(ctx, "unknown-key")
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{}, sources)
+
+	// look up contents by key
+	contents, err := inMemoryStore.LookUpByKey(ctx, key1)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []*event.Message{
+		event.NewMessage(key1, source1, "content1-1"),
+		event.NewMessage(key1, source2, "content1-2"),
+	}, contents)
+	contents, err = inMemoryStore.LookUpByKey(ctx, key2)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []*event.Message{event.NewMessage(key2, source1, "content2-1")}, contents)
+	contents, err = inMemoryStore.LookUpByKey(ctx, "unknown-key")
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{}, contents)
+
+	// look up contents
+	content, err := inMemoryStore.LookUp(ctx, key1, source1)
+	assert.NoError(t, err)
+	assert.Equal(t, event.NewMessage(key1, source1, "content1-1"), content)
+	content, err = inMemoryStore.LookUp(ctx, key1, source2)
+	assert.NoError(t, err)
+	assert.Equal(t, event.NewMessage(key1, source2, "content1-2"), content)
+	content, err = inMemoryStore.LookUp(ctx, key2, source1)
+	assert.NoError(t, err)
+	assert.Equal(t, event.NewMessage(key2, source1, "content2-1"), content)
+	content, err = inMemoryStore.LookUp(ctx, key2, source2)
+	assert.NoError(t, err)
+	assert.Nil(t, content)
+}


### PR DESCRIPTION


## Checklist
- [x] I've run and passed `make commit` (requires [`pre-commit`](https://pre-commit.com) command been installed).
- [x] I've put adequate descriptions that explains why this change is made.

## Description
Issue: https://github.com/lukecold/event-driver/issues/42

The `GCSEventStore` downloads all files under the key when calling `#LookUpByKey`, which is inefficient when the joiner requires more than 2 sources.

This PR adds an additional function `ListSourcesByKey` that returns all sources in `EventStore`.