### PR TITLE
feat: Support compressing the data before writing into GCS

### DIFF
--- a/extensions/google-cloud/storage/gcs_event_store/gcs_config.go
+++ b/extensions/google-cloud/storage/gcs_event_store/gcs_config.go
@@ -3,6 +3,8 @@ package gcs_event_store
 import (
 	"context"
 	"time"
+
+	"github.com/lukecold/event-driver/utils/compression"
 )
 
 type Operation string
@@ -14,9 +16,10 @@ const (
 )
 
 type GCSConfig struct {
-	Bucket  string
-	Folder  *string
-	Timeout Timeout
+	Bucket     string
+	Compressor compression.Compressor
+	Folder     *string
+	Timeout    Timeout
 }
 
 type Timeout struct {
@@ -26,12 +29,19 @@ type Timeout struct {
 
 func Config(bucket string) *GCSConfig {
 	return &GCSConfig{
-		Bucket: bucket,
+		Bucket:     bucket,
+		Compressor: compression.Noop(),
 		Timeout: Timeout{
 			Default:   nil,
 			Operation: make(map[Operation]time.Duration),
 		},
 	}
+}
+
+func (c *GCSConfig) WithCompressor(compressor compression.Compressor) *GCSConfig {
+	c.Compressor = compressor
+
+	return c
 }
 
 func (c *GCSConfig) WithFolder(folder string) *GCSConfig {

--- a/extensions/google-cloud/storage/gcs_event_store/gcs_event_store_test.go
+++ b/extensions/google-cloud/storage/gcs_event_store/gcs_event_store_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/lukecold/event-driver/event"
 	"github.com/lukecold/event-driver/extensions/google-cloud/storage/gcs_event_store"
+	"github.com/lukecold/event-driver/utils/compression"
 )
 
 const (

--- a/extensions/google-cloud/storage/gcs_event_store/gcs_event_store_test.go
+++ b/extensions/google-cloud/storage/gcs_event_store/gcs_event_store_test.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
-	"github.com/lukecold/event-driver/utils/compression"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/option"
 
@@ -31,7 +31,6 @@ func TestGCSEventStore(t *testing.T) {
 		folderName := "folder-name"
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			fmt.Println(r.URL.Path)
 			switch {
 			case strings.HasPrefix(r.URL.Path, "/upload/"): // write operation
 				body, err := io.ReadAll(r.Body)
@@ -76,7 +75,6 @@ func TestGCSEventStore(t *testing.T) {
 	t.Run("without folder prefix", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			fmt.Println(r.URL.Path)
 			switch {
 			case strings.HasPrefix(r.URL.Path, "/upload/"): // write operation
 				body, err := io.ReadAll(r.Body)
@@ -125,7 +123,6 @@ func TestGCSEventStore(t *testing.T) {
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			fmt.Println(r.URL.Path)
 			switch {
 			case strings.HasPrefix(r.URL.Path, "/upload/"): // write operation
 				body, err := io.ReadAll(r.Body)
@@ -165,5 +162,37 @@ func TestGCSEventStore(t *testing.T) {
 		messageArray, err := eventStore.LookUpByKey(context.TODO(), key)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(messageArray))
+	})
+
+	t.Run("gcs error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			switch {
+			case strings.HasPrefix(r.URL.Path, "/upload/"): // write operation
+			case strings.HasPrefix(r.URL.Path, fmt.Sprintf("/bucket/%s/%s", key, source)): // read operation
+			case strings.HasPrefix(r.URL.Path, "/storage/v1/b/bucket/o"): // list operation
+				w.Write([]byte(`{}`))
+			}
+		}))
+		defer server.Close()
+
+		os.Setenv("STORAGE_EMULATOR_HOST", server.URL)
+
+		millisecond := time.Millisecond
+		config := gcs_event_store.Config("bucket").WithTimeout(gcs_event_store.Timeout{Default: &millisecond})
+		eventStore, err := gcs_event_store.New(context.TODO(), config, option.WithoutAuthentication())
+		assert.NoError(t, err)
+
+		err = eventStore.Persist(context.TODO(), key, source, content)
+		assert.Error(t, err)
+
+		_, err = eventStore.ListSourcesByKey(context.TODO(), key)
+		assert.Error(t, err)
+
+		_, err = eventStore.LookUp(context.TODO(), key, source)
+		assert.Error(t, err)
+
+		_, err = eventStore.LookUpByKey(context.TODO(), key)
+		assert.Error(t, err)
 	})
 }

--- a/extensions/google-cloud/storage/gcs_event_store/gcs_event_store_test.go
+++ b/extensions/google-cloud/storage/gcs_event_store/gcs_event_store_test.go
@@ -1,6 +1,7 @@
 package gcs_event_store_test
 
 import (
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/lukecold/event-driver/utils/compression"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/option"
 
@@ -96,6 +98,55 @@ func TestGCSEventStore(t *testing.T) {
 		os.Setenv("STORAGE_EMULATOR_HOST", server.URL)
 
 		config := gcs_event_store.Config("bucket")
+		eventStore, err := gcs_event_store.New(context.TODO(), config, option.WithoutAuthentication())
+		assert.NoError(t, err)
+
+		err = eventStore.Persist(context.TODO(), key, source, content)
+		assert.NoError(t, err)
+
+		sources, err := eventStore.ListSourcesByKey(context.TODO(), key)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(sources))
+
+		message, err := eventStore.LookUp(context.TODO(), key, source)
+		assert.NoError(t, err)
+		assert.Equal(t, event.NewMessage(key, source, content), message)
+
+		messageArray, err := eventStore.LookUpByKey(context.TODO(), key)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(messageArray))
+	})
+
+	t.Run("with compression", func(t *testing.T) {
+		compressor := compression.Gzip(gzip.BestSpeed)
+		compressedContent, err := compressor.Compress([]byte(content))
+		assert.NoError(t, err)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Println(r.URL.Path)
+			switch {
+			case strings.HasPrefix(r.URL.Path, "/upload/"): // write operation
+				body, err := io.ReadAll(r.Body)
+				assert.NoError(t, err)
+				// assert that bucket, key, source, and content match
+				assert.Contains(t, string(body), fmt.Sprintf(`{"bucket":"bucket","name":"%s/%s"}`, key, source))
+				assert.Contains(t, string(body), string(compressedContent))
+				w.Write([]byte("{}"))
+			case strings.HasPrefix(r.URL.Path, fmt.Sprintf("/bucket/%s/%s", key, source)): // read operation
+				w.Write(compressedContent)
+			case strings.HasPrefix(r.URL.Path, "/storage/v1/b/bucket/o"): // list operation
+				w.Write([]byte(`{
+				"kind":"storage#objects",
+				"items":[{"kind":"storage#object","name":"key/source1"},{"kind":"storage#object","name":"key/source2"}]
+			}`))
+			}
+		}))
+		defer server.Close()
+
+		os.Setenv("STORAGE_EMULATOR_HOST", server.URL)
+
+		config := gcs_event_store.Config("bucket").WithCompressor(compression.Gzip(gzip.BestSpeed))
 		eventStore, err := gcs_event_store.New(context.TODO(), config, option.WithoutAuthentication())
 		assert.NoError(t, err)
 

--- a/utils/compression/compressors.go
+++ b/utils/compression/compressors.go
@@ -1,0 +1,70 @@
+package compression
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+)
+
+type Compressor interface {
+	Compress(input []byte) ([]byte, error)
+	Decompress(input []byte) ([]byte, error)
+}
+
+type gzipCompressor struct {
+	level int
+}
+
+func Gzip(level int) Compressor {
+	return gzipCompressor{
+		level: level,
+	}
+}
+
+func (g gzipCompressor) Compress(input []byte) ([]byte, error) {
+	if len(input) == 0 {
+		return input, nil
+	}
+	var buffer bytes.Buffer
+	gzipWriter, _ := gzip.NewWriterLevel(&buffer, g.level)
+
+	_, err := gzipWriter.Write(input)
+	if err != nil {
+		return nil, err
+	}
+	err = gzipWriter.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), err
+}
+
+func (g gzipCompressor) Decompress(input []byte) ([]byte, error) {
+	if len(input) == 0 {
+		return input, nil
+	}
+	byteReader := bytes.NewReader(input)
+	gzipReader, err := gzip.NewReader(byteReader)
+	if err != nil {
+		return nil, err
+	}
+	defer gzipReader.Close()
+
+	return io.ReadAll(gzipReader)
+}
+
+type noop struct {
+}
+
+func Noop() Compressor {
+	return noop{}
+}
+
+func (n noop) Compress(input []byte) ([]byte, error) {
+	return input, nil
+}
+
+func (n noop) Decompress(input []byte) ([]byte, error) {
+	return input, nil
+}

--- a/utils/compression/compressors_test.go
+++ b/utils/compression/compressors_test.go
@@ -12,13 +12,25 @@ func TestGzip(t *testing.T) {
 	input := []byte("test string")
 	compressor := compression.Gzip(gzip.BestSpeed)
 
-	compressed, err := compressor.Compress(input)
-	assert.NoError(t, err)
-	assert.NotEqual(t, input, compressed)
+	t.Run("round trip", func(t *testing.T) {
+		compressed, err := compressor.Compress(input)
+		assert.NoError(t, err)
+		assert.NotEqual(t, input, compressed)
 
-	roundTripped, err := compressor.Decompress(compressed)
-	assert.NoError(t, err)
-	assert.Equal(t, input, roundTripped)
+		roundTripped, err := compressor.Decompress(compressed)
+		assert.NoError(t, err)
+		assert.Equal(t, input, roundTripped)
+	})
+
+	t.Run("empty bytes", func(t *testing.T) {
+		compressed, err := compressor.Compress([]byte{})
+		assert.NoError(t, err)
+		assert.Equal(t, []byte{}, compressed)
+
+		decompressed, err := compressor.Decompress([]byte{})
+		assert.NoError(t, err)
+		assert.Equal(t, []byte{}, decompressed)
+	})
 }
 
 func TestNoop(t *testing.T) {

--- a/utils/compression/compressors_test.go
+++ b/utils/compression/compressors_test.go
@@ -1,0 +1,35 @@
+package compression_test
+
+import (
+	"compress/gzip"
+	"testing"
+
+	"github.com/lukecold/event-driver/utils/compression"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGzip(t *testing.T) {
+	input := []byte("test string")
+	compressor := compression.Gzip(gzip.BestSpeed)
+
+	compressed, err := compressor.Compress(input)
+	assert.NoError(t, err)
+	assert.NotEqual(t, input, compressed)
+
+	roundTripped, err := compressor.Decompress(compressed)
+	assert.NoError(t, err)
+	assert.Equal(t, input, roundTripped)
+}
+
+func TestNoop(t *testing.T) {
+	input := []byte("test string")
+	compressor := compression.Noop()
+
+	compressed, err := compressor.Compress(input)
+	assert.NoError(t, err)
+	assert.Equal(t, input, compressed)
+
+	roundTripped, err := compressor.Decompress(compressed)
+	assert.NoError(t, err)
+	assert.Equal(t, input, roundTripped)
+}


### PR DESCRIPTION
## Checklist
- [x] I've run and passed `make commit` (requires [`pre-commit`](https://pre-commit.com) command been installed).
- [x] I've put adequate descriptions that explains why this change is made.

## Description
Issue: https://github.com/lukecold/event-driver/issues/41

The current event-driver google cloud extension read and write the data to GCS as plain text, which is both insecure and consumes more network bandwidth and storage space. By compressing the data before writing into GCS, It would reduce the storage size and internet traffic, which could improve the performance of the framework.

The framework doesn't do any compression by default. One need to configure a compressor to enfore compression/decompression in GCS r/w. e.g.
```golang
config := gcs_event_store.Config("bucket").WithCompressor(compression.Gzip(gzip.BestSpeed))
eventStore, err := gcs_event_store.New(ctx, config)
```