### PR TITLE
feat(joiner+transformer)!: Make joiner be able to join the map typed contents as is

### DIFF
--- a/handlers/transformer/rules_test.go
+++ b/handlers/transformer/rules_test.go
@@ -16,11 +16,34 @@ const (
 	content = "test-content"
 )
 
+func TestEraseContentFromSources(t *testing.T) {
+	eraseContentFromSources := transformer.EraseContentFromSources("source1", "source2")
+
+	inputSourceToTransformedContent := map[string]string{
+		"source1": "",
+		"source2": "",
+		"source3": content,
+	}
+
+	for inputSource, expectedTransformedContent := range inputSourceToTransformedContent {
+		testName := fmt.Sprintf("transform %s", inputSource)
+		t.Run(testName, func(t *testing.T) {
+			transformed, err := eraseContentFromSources.Transform(event.NewMessage(key, inputSource, content))
+			assert.NoError(t, err)
+			assert.Equal(t, key, transformed.GetKey())
+			assert.Equal(t, inputSource, transformed.GetSource())
+			assert.Equal(t, expectedTransformedContent, transformed.GetContent())
+		})
+	}
+}
+
 func TestIdentityRule(t *testing.T) {
 	identity := transformer.Identity()
 	message := event.NewMessage(key, source, content)
 
-	assert.Equal(t, message, identity.Transform(message))
+	transformed, err := identity.Transform(message)
+	assert.NoError(t, err)
+	assert.Equal(t, message, transformed)
 }
 
 func TestRenameSourcesRule(t *testing.T) {
@@ -39,30 +62,11 @@ func TestRenameSourcesRule(t *testing.T) {
 	for inputSource, expectedTransformedSource := range inputSourceToTransformedSource {
 		testName := fmt.Sprintf("transform %s", inputSource)
 		t.Run(testName, func(t *testing.T) {
-			transformed := renameSources.Transform(event.NewMessage(key, inputSource, content))
+			transformed, err := renameSources.Transform(event.NewMessage(key, inputSource, content))
+			assert.NoError(t, err)
 			assert.Equal(t, key, transformed.GetKey())
 			assert.Equal(t, expectedTransformedSource, transformed.GetSource())
 			assert.Equal(t, content, transformed.GetContent())
-		})
-	}
-}
-
-func TestEraseContentFromSources(t *testing.T) {
-	eraseContentFromSources := transformer.EraseContentFromSources("source1", "source2")
-
-	inputSourceToTransformedContent := map[string]string{
-		"source1": "",
-		"source2": "",
-		"source3": content,
-	}
-
-	for inputSource, expectedTransformedContent := range inputSourceToTransformedContent {
-		testName := fmt.Sprintf("transform %s", inputSource)
-		t.Run(testName, func(t *testing.T) {
-			transformed := eraseContentFromSources.Transform(event.NewMessage(key, inputSource, content))
-			assert.Equal(t, key, transformed.GetKey())
-			assert.Equal(t, inputSource, transformed.GetSource())
-			assert.Equal(t, expectedTransformedContent, transformed.GetContent())
 		})
 	}
 }

--- a/handlers/transformer/transformer.go
+++ b/handlers/transformer/transformer.go
@@ -44,7 +44,12 @@ func (m *transformer) WithRules(rules ...Rule) *transformer {
 
 func (m *transformer) Process(ctx context.Context, in *event.Message, next handlers.CallNext) error {
 	logger := m.logger.With(slog.String("key", in.GetKey()), slog.String("source", in.GetSource()))
-	transformed := m.rule.Transform(in)
+	transformed, err := m.rule.Transform(in)
+	if err != nil {
+		logger.Error("failed to transform message", slog.Any("error", err))
+
+		return err
+	}
 	logger.Debug("transformed message")
 
 	return next.Call(ctx, transformed)

--- a/utils/reflect/reflect.go
+++ b/utils/reflect/reflect.go
@@ -1,0 +1,16 @@
+package reflect
+
+import (
+	"reflect"
+)
+
+func GetType(object interface{}) string {
+	pointers := ""
+	t := reflect.TypeOf(object)
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+		pointers += "*"
+	}
+
+	return pointers + t.Name()
+}

--- a/utils/reflect/reflect_test.go
+++ b/utils/reflect/reflect_test.go
@@ -1,0 +1,49 @@
+package reflect_test
+
+import (
+	"testing"
+
+	"github.com/lukecold/event-driver/utils/reflect"
+	"github.com/stretchr/testify/assert"
+)
+
+type testInterface interface{}
+
+type testStruct struct{}
+
+func makeTestStruct() testInterface {
+	return testStruct{}
+}
+
+func TestGetType(t *testing.T) {
+	t.Run("primitive", func(t *testing.T) {
+		integer := 1
+		integerType := reflect.GetType(integer)
+		assert.Equal(t, "int", integerType)
+
+		stringType := reflect.GetType("test string")
+		assert.Equal(t, "string", stringType)
+	})
+
+	t.Run("primitive pointer", func(t *testing.T) {
+		str := "test string"
+		stringType := reflect.GetType(&str)
+		assert.Equal(t, "*string", stringType)
+	})
+
+	t.Run("struct from interface", func(t *testing.T) {
+		objectType := reflect.GetType(makeTestStruct())
+		assert.Equal(t, "testStruct", objectType)
+	})
+
+	t.Run("struct pointer", func(t *testing.T) {
+		objectType := reflect.GetType(&testStruct{})
+		assert.Equal(t, "*testStruct", objectType)
+	})
+
+	t.Run("struct pointer of pointer", func(t *testing.T) {
+		objectPtr := &testStruct{}
+		objectType := reflect.GetType(&objectPtr)
+		assert.Equal(t, "**testStruct", objectType)
+	})
+}


### PR DESCRIPTION
## Checklist
- [x] I've run and passed `make commit` (requires [`pre-commit`](https://pre-commit.com) command been installed).
- [x] I've put adequate descriptions that explains why this change is made.

## Description

### Motivation
Issue: https://github.com/lukecold/event-driver/issues/44

The `joiner` handler generates a JSON message from `map[string]string`, which would escape the quotes in the original contents.

For example:
```golang
message1 := {
    key: "key",
    source: "source1",
    content: `{"k":"v"}`,
}
message2 := {
    key: "key",
    source: "source2",
    content: `{"k":"v"}`,
}
```
would be joined into
```golang
{
    key: "key",
    source: "composed-event",
    content: `{"source1": "{\"k\":\"v\"}", "source2": "{\"k\":\"v\"}"}`,
}
```

The joint message content above cannot be easily unmarshaled into object
```golang
type JointMessage struct {
    message1 Message `json:"source1"`
    message2 Message `json:"source2"`
}

type Message struct {
    key    string `json:"k"`
    value string `json:"v"`
}
```

This PR is meant to solve this problem.

### Changes

This is a **BREAKING CHANGE**
1. The `joiner` keeps the map-typed contents as is in the joint message. Previously they would be converted to quote-escaped strings.
2. The `rule` of `transformer` is able to return an error
3. The `pipeline` logs the name of the handlers that failed/timed out during process