### PR TITLE
fix: Handle the content not found gracefully

### DIFF
--- a/extensions/google-cloud/go.mod
+++ b/extensions/google-cloud/go.mod
@@ -7,6 +7,7 @@ replace github.com/honestbank/event-driver => ../../../event-driver
 require (
 	cloud.google.com/go/storage v1.40.0
 	github.com/honestbank/event-driver v1.0.0
+	github.com/samber/lo v1.39.0
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/mock v0.4.0
 	google.golang.org/api v0.175.0
@@ -37,6 +38,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.25.0 // indirect
 	go.opentelemetry.io/otel/trace v1.25.0 // indirect
 	golang.org/x/crypto v0.23.0 // indirect
+	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/oauth2 v0.19.0 // indirect

--- a/extensions/google-cloud/go.sum
+++ b/extensions/google-cloud/go.sum
@@ -75,6 +75,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/samber/lo v1.39.0 h1:4gTz1wUhNYLhFSKl6O+8peW0v2F4BCY034GRpU9WnuA=
+github.com/samber/lo v1.39.0/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -104,6 +106,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.23.0 h1:dIJU/v2J8Mdglj/8rJ6UUOM3Zc9zLZxVZwwxMooUSAI=
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 h1:3MTrJm4PyNL9NBqvYDSj3DHl46qQakyfqfWo4jgfaEM=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/extensions/google-cloud/storage/gcs_event_store/gcs_event_store.go
+++ b/extensions/google-cloud/storage/gcs_event_store/gcs_event_store.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	gcs "cloud.google.com/go/storage"
+	"github.com/samber/lo"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 
@@ -56,16 +57,16 @@ func (g *GCSEventStore) ListSourcesByKey(ctx context.Context, key string) ([]str
 			break
 		}
 		if err != nil {
-			return sources, err
+			return lo.Uniq(sources), err
 		}
 		_, source, err := parsePath(object.Prefix)
 		if err != nil {
-			return sources, err
+			return lo.Uniq(sources), err
 		}
 		sources = append(sources, source)
 	}
 
-	return sources, nil
+	return lo.Uniq(sources), nil
 }
 
 // LookUp returns a single message by looking up the path `folder/key/source`.
@@ -89,37 +90,21 @@ func (g *GCSEventStore) LookUp(ctx context.Context, key, source string) (*event.
 
 // LookUpByKey returns a list of messages by looking up the prefix `folder/key/`.
 func (g *GCSEventStore) LookUpByKey(ctx context.Context, key string) ([]*event.Message, error) {
-	bucket := g.client.Bucket(g.cfg.Bucket)
-
 	messages := make([]*event.Message, 0)
-	listRequestCtx, cancel := g.cfg.NewContextWithTimeout(ctx, ListContents)
-	defer cancel()
-
-	sourceIterator := bucket.Objects(listRequestCtx, &gcs.Query{
-		Prefix:    composePath(g.cfg.Folder, key) + "/",
-		Delimiter: "/",
-	})
-	for {
-		path, err := sourceIterator.Next()
-		if errors.Is(err, iterator.Done) {
-			break
-		}
+	sources, err := g.ListSourcesByKey(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	for _, source := range sources {
+		message, err := g.LookUp(ctx, key, source)
 		if err != nil {
 			return messages, err
 		}
-		readRequestCtx, _ := g.cfg.NewContextWithTimeout(ctx, ReadContent)
-		content, err := readFile(readRequestCtx, g.cfg.Compressor, bucket, path.Prefix, g.cfg.ReadPolicy)
-		if err != nil {
-			return messages, err
-		}
-		if content == nil {
+		if message == nil {
 			continue
 		}
-		key, source, err := parsePath(path.Prefix)
-		if err != nil {
-			return messages, err
-		}
-		messages = append(messages, event.NewMessage(key, source, string(content)))
+
+		messages = append(messages, message)
 	}
 
 	return messages, nil

--- a/extensions/google-cloud/storage/gcs_event_store/gcs_event_store.go
+++ b/extensions/google-cloud/storage/gcs_event_store/gcs_event_store.go
@@ -177,10 +177,6 @@ func readFile(
 	}
 	reader, err := bucket.Object(object.Name).NewReader(ctx)
 	if err != nil {
-		if errors.Is(err, gcs.ErrObjectNotExist) {
-			return nil, nil
-		}
-
 		return nil, err
 	}
 	compressedContent, err := io.ReadAll(reader)

--- a/extensions/google-cloud/storage/gcs_event_store/gcs_event_store.go
+++ b/extensions/google-cloud/storage/gcs_event_store/gcs_event_store.go
@@ -112,6 +112,9 @@ func (g *GCSEventStore) LookUpByKey(ctx context.Context, key string) ([]*event.M
 		if err != nil {
 			return messages, err
 		}
+		if content == nil {
+			continue
+		}
 		key, source, err := parsePath(path.Prefix)
 		if err != nil {
 			return messages, err
@@ -168,6 +171,9 @@ func readFile(
 	object, err := readPolicy.Apply(objectIterator)
 	if err != nil {
 		return nil, err
+	}
+	if object == nil {
+		return nil, nil
 	}
 	reader, err := bucket.Object(object.Name).NewReader(ctx)
 	if err != nil {

--- a/extensions/google-cloud/storage/gcs_event_store/gcs_event_store_test.go
+++ b/extensions/google-cloud/storage/gcs_event_store/gcs_event_store_test.go
@@ -43,7 +43,7 @@ func TestGCSEventStore(t *testing.T) {
 
 		sources, err := eventStore.ListSourcesByKey(context.TODO(), key)
 		assert.NoError(t, err)
-		assert.ElementsMatch(t, []string{}, sources)
+		assert.Equal(t, []string{}, sources)
 
 		message, err := eventStore.LookUp(context.TODO(), key, source1)
 		assert.NoError(t, err)
@@ -51,7 +51,7 @@ func TestGCSEventStore(t *testing.T) {
 
 		messageArray, err := eventStore.LookUpByKey(context.TODO(), key)
 		assert.NoError(t, err)
-		assert.ElementsMatch(t, []*event.Message{}, messageArray)
+		assert.Equal(t, []*event.Message{}, messageArray)
 	})
 
 	t.Run("with folder prefix", func(t *testing.T) {
@@ -61,14 +61,14 @@ func TestGCSEventStore(t *testing.T) {
 		eventStore, err := gcs_event_store.New(context.TODO(), config, option.WithoutAuthentication())
 		assert.NoError(t, err)
 
-		err = eventStore.Persist(context.TODO(), key, source1, content)
-		assert.NoError(t, err)
 		err = eventStore.Persist(context.TODO(), key, source2, content)
+		assert.NoError(t, err)
+		err = eventStore.Persist(context.TODO(), key, source1, content)
 		assert.NoError(t, err)
 
 		sources, err := eventStore.ListSourcesByKey(context.TODO(), key)
 		assert.NoError(t, err)
-		assert.ElementsMatch(t, []string{source1, source2}, sources)
+		assert.Equal(t, []string{source1, source2}, sources)
 
 		message, err := eventStore.LookUp(context.TODO(), key, source1)
 		assert.NoError(t, err)
@@ -76,7 +76,7 @@ func TestGCSEventStore(t *testing.T) {
 
 		messageArray, err := eventStore.LookUpByKey(context.TODO(), key)
 		assert.NoError(t, err)
-		assert.ElementsMatch(t, []*event.Message{
+		assert.Equal(t, []*event.Message{
 			event.NewMessage(key, source1, content),
 			event.NewMessage(key, source2, content)},
 			messageArray)
@@ -96,7 +96,7 @@ func TestGCSEventStore(t *testing.T) {
 
 		sources, err := eventStore.ListSourcesByKey(context.TODO(), key)
 		assert.NoError(t, err)
-		assert.ElementsMatch(t, []string{source1, source2}, sources)
+		assert.Equal(t, []string{source1, source2}, sources)
 
 		message, err := eventStore.LookUp(context.TODO(), key, source1)
 		assert.NoError(t, err)
@@ -104,7 +104,7 @@ func TestGCSEventStore(t *testing.T) {
 
 		messageArray, err := eventStore.LookUpByKey(context.TODO(), key)
 		assert.NoError(t, err)
-		assert.ElementsMatch(t, []*event.Message{
+		assert.Equal(t, []*event.Message{
 			event.NewMessage(key, source1, content),
 			event.NewMessage(key, source2, content)},
 			messageArray)

--- a/extensions/google-cloud/storage/gcs_event_store/gcs_event_store_test.go
+++ b/extensions/google-cloud/storage/gcs_event_store/gcs_event_store_test.go
@@ -34,6 +34,26 @@ func TestGCSEventStore(t *testing.T) {
 	_ = os.Setenv("STORAGE_EMULATOR_HOST", "localhost:19081")
 	folderName := "folder-name"
 
+	t.Run("query empty bucket", func(t *testing.T) {
+		bucket := "empty-bucket"
+		setup(t, bucket)
+		config := gcs_event_store.Config(bucket).WithFolder(folderName)
+		eventStore, err := gcs_event_store.New(context.TODO(), config, option.WithoutAuthentication())
+		assert.NoError(t, err)
+
+		sources, err := eventStore.ListSourcesByKey(context.TODO(), key)
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, []string{}, sources)
+
+		message, err := eventStore.LookUp(context.TODO(), key, source1)
+		assert.NoError(t, err)
+		assert.Nil(t, message)
+
+		messageArray, err := eventStore.LookUpByKey(context.TODO(), key)
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, []*event.Message{}, messageArray)
+	})
+
 	t.Run("with folder prefix", func(t *testing.T) {
 		bucket := "with-prefix"
 		setup(t, bucket)

--- a/extensions/google-cloud/storage/gcs_event_store/gcs_event_store_test.go
+++ b/extensions/google-cloud/storage/gcs_event_store/gcs_event_store_test.go
@@ -43,7 +43,7 @@ func TestGCSEventStore(t *testing.T) {
 
 		sources, err := eventStore.ListSourcesByKey(context.TODO(), key)
 		assert.NoError(t, err)
-		assert.Equal(t, []string{}, sources)
+		assert.ElementsMatch(t, []string{}, sources)
 
 		message, err := eventStore.LookUp(context.TODO(), key, source1)
 		assert.NoError(t, err)
@@ -51,7 +51,7 @@ func TestGCSEventStore(t *testing.T) {
 
 		messageArray, err := eventStore.LookUpByKey(context.TODO(), key)
 		assert.NoError(t, err)
-		assert.Equal(t, []*event.Message{}, messageArray)
+		assert.ElementsMatch(t, []*event.Message{}, messageArray)
 	})
 
 	t.Run("with folder prefix", func(t *testing.T) {
@@ -61,14 +61,16 @@ func TestGCSEventStore(t *testing.T) {
 		eventStore, err := gcs_event_store.New(context.TODO(), config, option.WithoutAuthentication())
 		assert.NoError(t, err)
 
-		err = eventStore.Persist(context.TODO(), key, source2, content)
-		assert.NoError(t, err)
 		err = eventStore.Persist(context.TODO(), key, source1, content)
+		assert.NoError(t, err)
+		err = eventStore.Persist(context.TODO(), key, source1, "something else")
+		assert.NoError(t, err)
+		err = eventStore.Persist(context.TODO(), key, source2, content)
 		assert.NoError(t, err)
 
 		sources, err := eventStore.ListSourcesByKey(context.TODO(), key)
 		assert.NoError(t, err)
-		assert.Equal(t, []string{source1, source2}, sources)
+		assert.ElementsMatch(t, []string{source1, source2}, sources)
 
 		message, err := eventStore.LookUp(context.TODO(), key, source1)
 		assert.NoError(t, err)
@@ -76,7 +78,7 @@ func TestGCSEventStore(t *testing.T) {
 
 		messageArray, err := eventStore.LookUpByKey(context.TODO(), key)
 		assert.NoError(t, err)
-		assert.Equal(t, []*event.Message{
+		assert.ElementsMatch(t, []*event.Message{
 			event.NewMessage(key, source1, content),
 			event.NewMessage(key, source2, content)},
 			messageArray)
@@ -91,12 +93,14 @@ func TestGCSEventStore(t *testing.T) {
 
 		err = eventStore.Persist(context.TODO(), key, source1, content)
 		assert.NoError(t, err)
+		err = eventStore.Persist(context.TODO(), key, source1, "something else")
+		assert.NoError(t, err)
 		err = eventStore.Persist(context.TODO(), key, source2, content)
 		assert.NoError(t, err)
 
 		sources, err := eventStore.ListSourcesByKey(context.TODO(), key)
 		assert.NoError(t, err)
-		assert.Equal(t, []string{source1, source2}, sources)
+		assert.ElementsMatch(t, []string{source1, source2}, sources)
 
 		message, err := eventStore.LookUp(context.TODO(), key, source1)
 		assert.NoError(t, err)
@@ -104,8 +108,40 @@ func TestGCSEventStore(t *testing.T) {
 
 		messageArray, err := eventStore.LookUpByKey(context.TODO(), key)
 		assert.NoError(t, err)
-		assert.Equal(t, []*event.Message{
+		assert.ElementsMatch(t, []*event.Message{
 			event.NewMessage(key, source1, content),
+			event.NewMessage(key, source2, content)},
+			messageArray)
+	})
+
+	t.Run("take last created", func(t *testing.T) {
+		bucket := "without-prefix"
+		setup(t, bucket)
+		config := gcs_event_store.Config(bucket).
+			WithFolder(folderName).
+			WithReadPolicy(gcs_event_store.TakeLastCreated())
+		eventStore, err := gcs_event_store.New(context.TODO(), config, option.WithoutAuthentication())
+		assert.NoError(t, err)
+
+		err = eventStore.Persist(context.TODO(), key, source1, content)
+		assert.NoError(t, err)
+		err = eventStore.Persist(context.TODO(), key, source1, "something else")
+		assert.NoError(t, err)
+		err = eventStore.Persist(context.TODO(), key, source2, content)
+		assert.NoError(t, err)
+
+		sources, err := eventStore.ListSourcesByKey(context.TODO(), key)
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, []string{source1, source2}, sources)
+
+		message, err := eventStore.LookUp(context.TODO(), key, source1)
+		assert.NoError(t, err)
+		assert.Equal(t, event.NewMessage(key, source1, "something else"), message)
+
+		messageArray, err := eventStore.LookUpByKey(context.TODO(), key)
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, []*event.Message{
+			event.NewMessage(key, source1, "something else"),
 			event.NewMessage(key, source2, content)},
 			messageArray)
 	})
@@ -118,6 +154,8 @@ func TestGCSEventStore(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = eventStore.Persist(context.TODO(), key, source1, content)
+		assert.NoError(t, err)
+		err = eventStore.Persist(context.TODO(), key, source1, "something else")
 		assert.NoError(t, err)
 		err = eventStore.Persist(context.TODO(), key, source2, content)
 		assert.NoError(t, err)


### PR DESCRIPTION

<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

The lib panics when it couldn't find the content under the queried path, since it always assumes that the returned object is non-null.

This PR changes the lib to 
- return a nil for caller to handle gracefully in such cases.
- dedupe the source names when there are multiple contents under the same source.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/event-driver/58)
<!-- Reviewable:end -->
